### PR TITLE
mosquitto: add labels support to PVC volumeClaimTemplate

### DIFF
--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mosquitto/templates/statefulset.yaml
+++ b/charts/mosquitto/templates/statefulset.yaml
@@ -149,6 +149,10 @@ spec:
     kind: PersistentVolumeClaim
     metadata:
       name: data
+      {{- with .Values.persistence.labels }}
+      labels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       accessModes:
       - {{ .Values.persistence.accessMode }}

--- a/charts/mosquitto/values.yaml
+++ b/charts/mosquitto/values.yaml
@@ -38,6 +38,7 @@ persistence:
   existingClaim: ""
   mountPath: /mosquitto/data
   subPath: ""
+  labels: {}
   ## database data Persistent Volume Storage Class
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
Add `persistence.labels` values field and render it into the StatefulSet `volumeClaimTemplate` metadata, allowing custom labels on the PVC.

### Usage
```yaml
persistence:
  labels:
    backup: "yes"
```
