### PR TITLE
feat: add lunasea-web Helm chart

### DIFF
--- a/charts/lunasea-web/Chart.yaml
+++ b/charts/lunasea-web/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: lunasea-web
+description: Self-hosted web build of LunaSea — a controller dashboard for self-hosted media software (Radarr, Sonarr, Lidarr, SABnzbd, NZBGet, Tautulli, ...).
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed.
+# It is recommended to use it with quotes.
+# renovate: datasource=docker depName=ghcr.io/alysson-souza/lunasea-web
+appVersion: "0.4.0"
+
+home: https://github.com/alysson-souza/lunasea-web
+sources:
+  - https://github.com/alysson-souza/lunasea-web
+keywords:
+  - lunasea
+  - media
+  - dashboard
+  - radarr
+  - sonarr
+  - self-hosted

--- a/charts/lunasea-web/ci/default-values.yaml
+++ b/charts/lunasea-web/ci/default-values.yaml
@@ -1,0 +1,3 @@
+# Minimal install path for `ct install` in KinD: no dynamic storage assumptions.
+persistence:
+  enabled: false

--- a/charts/lunasea-web/ci/full-values.yaml
+++ b/charts/lunasea-web/ci/full-values.yaml
@@ -1,0 +1,30 @@
+# Exercises ingress + basic auth + secure contexts + resources.
+# httpRoute stays disabled: NGINX Gateway Fabric CRDs are not present in the CI
+# KinD cluster. The httpRoute / AuthenticationFilter path is validated locally
+# via `helm template`.
+persistence:
+  enabled: true
+  size: 128Mi
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
+
+basicAuth:
+  enabled: true
+  realm: LunaSea
+  # synthetic sample credential (user "demo"); never a real secret
+  htpasswd: "demo:$apr1$X6N4z1pP$mn5cYx8Qd7nO0rJ8a1Qe2/"
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: lunasea.chart-example.local
+      paths:
+        - path: /
+          pathType: Prefix

--- a/charts/lunasea-web/templates/NOTES.txt
+++ b/charts/lunasea-web/templates/NOTES.txt
@@ -1,0 +1,28 @@
+LunaSea Web has been deployed.
+
+LunaSea ships no built-in authentication. NEVER expose it directly to the public
+internet — keep it behind Basic Auth (this chart wires it for Ingress and the
+NGINX Gateway Fabric HTTPRoute) or a dedicated auth proxy.
+
+{{- if .Values.ingress.enabled }}
+
+It is reachable via Ingress at:
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}/
+{{- end }}
+{{- else if .Values.httpRoute.enabled }}
+
+It is reachable via the Gateway API HTTPRoute at:
+{{- range .Values.httpRoute.hostnames }}
+  https://{{ . }}/
+{{- end }}
+{{- else }}
+
+Get the application URL by running:
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "lunasea-web.fullname" . }} 8080:{{ .Values.service.port }}
+  # then open http://127.0.0.1:8080/
+{{- end }}
+{{- if .Values.basicAuth.enabled }}
+
+Basic Auth is ENABLED (realm: {{ .Values.basicAuth.realm }}).
+{{- end }}

--- a/charts/lunasea-web/templates/_helpers.tpl
+++ b/charts/lunasea-web/templates/_helpers.tpl
@@ -63,13 +63,6 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Name of the headless service used by the StatefulSet.
-*/}}
-{{- define "lunasea-web.headlessServiceName" -}}
-{{- printf "%s-headless" (include "lunasea-web.fullname" .) | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
 Resolve the Basic Auth secret name: use an existing secret if provided,
 otherwise the chart-managed secret.
 */}}

--- a/charts/lunasea-web/templates/_helpers.tpl
+++ b/charts/lunasea-web/templates/_helpers.tpl
@@ -1,0 +1,82 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "lunasea-web.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "lunasea-web.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "lunasea-web.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "lunasea-web.labels" -}}
+helm.sh/chart: {{ include "lunasea-web.chart" . }}
+{{ include "lunasea-web.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "lunasea-web.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lunasea-web.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "lunasea-web.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "lunasea-web.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name of the headless service used by the StatefulSet.
+*/}}
+{{- define "lunasea-web.headlessServiceName" -}}
+{{- printf "%s-headless" (include "lunasea-web.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Resolve the Basic Auth secret name: use an existing secret if provided,
+otherwise the chart-managed secret.
+*/}}
+{{- define "lunasea-web.basicAuthSecretName" -}}
+{{- if .Values.basicAuth.existingSecret }}
+{{- .Values.basicAuth.existingSecret }}
+{{- else }}
+{{- printf "%s-basic-auth" (include "lunasea-web.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}

--- a/charts/lunasea-web/templates/authenticationfilter.yaml
+++ b/charts/lunasea-web/templates/authenticationfilter.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.httpRoute.enabled .Values.basicAuth.enabled }}
+apiVersion: gateway.nginx.org/v1alpha1
+kind: AuthenticationFilter
+metadata:
+  name: {{ include "lunasea-web.fullname" . }}-basic-auth
+  labels:
+    {{- include "lunasea-web.labels" . | nindent 4 }}
+spec:
+  type: Basic
+  basic:
+    realm: {{ .Values.basicAuth.realm | quote }}
+    secretRef:
+      name: {{ include "lunasea-web.basicAuthSecretName" . }}
+{{- end }}

--- a/charts/lunasea-web/templates/httproute.yaml
+++ b/charts/lunasea-web/templates/httproute.yaml
@@ -22,20 +22,26 @@ spec:
   hostnames:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- /* LunaSea PWA assets the OS fetches without credentials when adding to the
+         home screen. Exempted from basic auth so the home-screen icon renders.
+         NGINX Gateway Fabric supports only Exact/PathPrefix (no regex), and
+         PathPrefix matches per segment, so each root-level icon is an Exact path. */}}
+  {{- $pwaPaths := list }}
+  {{- if .Values.httpRoute.bypassAuthForPWA }}
+  {{- $pwaPaths = list "/manifest.json" "/browserconfig.xml" "/favicon.ico" "/favicon-16x16.png" "/favicon-32x32.png" "/favicon-96x96.png" "/apple-icon-57x57.png" "/apple-icon-60x60.png" "/apple-icon-72x72.png" "/apple-icon-76x76.png" "/apple-icon-114x114.png" "/apple-icon-120x120.png" "/apple-icon-144x144.png" "/apple-icon-152x152.png" "/apple-icon-180x180.png" "/android-icon-36x36.png" "/android-icon-48x48.png" "/android-icon-72x72.png" "/android-icon-96x96.png" "/android-icon-144x144.png" "/android-icon-192x192.png" "/ms-icon-144x144.png" }}
+  {{- end }}
+  {{- $exactPublic := concat $pwaPaths (.Values.httpRoute.publicPaths | default (list)) }}
   rules:
-    {{- if and .Values.basicAuth.enabled (or .Values.httpRoute.publicPathPrefixes .Values.httpRoute.publicPaths) }}
-    # Public (unauthenticated) paths — e.g. the PWA manifest + icons, which the
-    # OS fetches without credentials when adding the site to the home screen.
+    {{- if and .Values.basicAuth.enabled (or .Values.httpRoute.publicPathPrefixes $exactPublic) }}
+    # Public (unauthenticated) paths served without the AuthenticationFilter.
     # Listed first; more specific path matches take precedence over "/".
-    # NB: PathPrefix matches per path segment ("/x" does not match "/x-1.png"),
-    # so root-level icon files must be listed under publicPaths (Exact).
     - matches:
         {{- range .Values.httpRoute.publicPathPrefixes }}
         - path:
             type: PathPrefix
             value: {{ . | quote }}
         {{- end }}
-        {{- range .Values.httpRoute.publicPaths }}
+        {{- range $exactPublic }}
         - path:
             type: Exact
             value: {{ . | quote }}

--- a/charts/lunasea-web/templates/httproute.yaml
+++ b/charts/lunasea-web/templates/httproute.yaml
@@ -23,6 +23,27 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
+    {{- if and .Values.basicAuth.enabled .Values.httpRoute.publicPathPrefixes }}
+    # Public (unauthenticated) paths — e.g. the PWA manifest + icons, which the
+    # OS fetches without credentials when adding the site to the home screen.
+    # Listed first; more specific path matches take precedence over "/".
+    - matches:
+        {{- range .Values.httpRoute.publicPathPrefixes }}
+        - path:
+            type: PathPrefix
+            value: {{ . | quote }}
+        {{- end }}
+      {{- with .Values.httpRoute.extraFilters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "lunasea-web.fullname" . }}
+          group: ""
+          kind: Service
+          port: {{ .Values.service.port }}
+          weight: 1
+    {{- end }}
     - matches:
         {{- with .Values.httpRoute.matches }}
         {{- toYaml . | nindent 8 }}

--- a/charts/lunasea-web/templates/httproute.yaml
+++ b/charts/lunasea-web/templates/httproute.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "lunasea-web.fullname" . }}
+  labels:
+    {{- include "lunasea-web.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    {{- range .Values.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      group: {{ .group | default "gateway.networking.k8s.io" }}
+      kind: {{ .kind | default "Gateway" }}
+      {{- with .sectionName }}
+      sectionName: {{ . }}
+      {{- end }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- with .Values.httpRoute.matches }}
+        {{- toYaml . | nindent 8 }}
+        {{- else }}
+        - path:
+            type: PathPrefix
+            value: /
+        {{- end }}
+      filters:
+        {{- if .Values.basicAuth.enabled }}
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.nginx.org
+            kind: AuthenticationFilter
+            name: {{ include "lunasea-web.fullname" . }}-basic-auth
+        {{- end }}
+        {{- with .Values.httpRoute.extraFilters }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      backendRefs:
+        - name: {{ include "lunasea-web.fullname" . }}
+          group: ""
+          kind: Service
+          port: {{ .Values.service.port }}
+          weight: 1
+{{- end }}

--- a/charts/lunasea-web/templates/httproute.yaml
+++ b/charts/lunasea-web/templates/httproute.yaml
@@ -23,14 +23,21 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
-    {{- if and .Values.basicAuth.enabled .Values.httpRoute.publicPathPrefixes }}
+    {{- if and .Values.basicAuth.enabled (or .Values.httpRoute.publicPathPrefixes .Values.httpRoute.publicPaths) }}
     # Public (unauthenticated) paths — e.g. the PWA manifest + icons, which the
     # OS fetches without credentials when adding the site to the home screen.
     # Listed first; more specific path matches take precedence over "/".
+    # NB: PathPrefix matches per path segment ("/x" does not match "/x-1.png"),
+    # so root-level icon files must be listed under publicPaths (Exact).
     - matches:
         {{- range .Values.httpRoute.publicPathPrefixes }}
         - path:
             type: PathPrefix
+            value: {{ . | quote }}
+        {{- end }}
+        {{- range .Values.httpRoute.publicPaths }}
+        - path:
+            type: Exact
             value: {{ . | quote }}
         {{- end }}
       {{- with .Values.httpRoute.extraFilters }}

--- a/charts/lunasea-web/templates/ingress.yaml
+++ b/charts/lunasea-web/templates/ingress.yaml
@@ -7,18 +7,7 @@
 {{- $_ := set $annotations "nginx.ingress.kubernetes.io/auth-secret" (include "lunasea-web.basicAuthSecretName" .) -}}
 {{- $_ := set $annotations "nginx.ingress.kubernetes.io/auth-realm" .Values.basicAuth.realm -}}
 {{- end -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set $annotations "kubernetes.io/ingress.class" .Values.ingress.className }}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -29,12 +18,12 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- with .Values.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
+    {{- range . }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -49,19 +38,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: {{ .pathType | default "Prefix" }}
-            {{- end }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/lunasea-web/templates/ingress.yaml
+++ b/charts/lunasea-web/templates/ingress.yaml
@@ -1,0 +1,67 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "lunasea-web.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $annotations := deepCopy .Values.ingress.annotations -}}
+{{- if .Values.basicAuth.enabled -}}
+{{- $_ := set $annotations "nginx.ingress.kubernetes.io/auth-type" "basic" -}}
+{{- $_ := set $annotations "nginx.ingress.kubernetes.io/auth-secret" (include "lunasea-web.basicAuthSecretName" .) -}}
+{{- $_ := set $annotations "nginx.ingress.kubernetes.io/auth-realm" .Values.basicAuth.realm -}}
+{{- end -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set $annotations "kubernetes.io/ingress.class" .Values.ingress.className }}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "lunasea-web.labels" . | nindent 4 }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: {{ .pathType | default "Prefix" }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/lunasea-web/templates/networkpolicy.yaml
+++ b/charts/lunasea-web/templates/networkpolicy.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- $root := . }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "lunasea-web.fullname" . }}
+  labels:
+    {{- include "lunasea-web.labels" . | nindent 4 }}
+    {{- with .Values.networkPolicy.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.networkPolicy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "lunasea-web.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # When ingressRules is empty, no ingress is permitted (default-deny).
+    {{- range .Values.networkPolicy.ingressRules }}
+    - from:
+        {{- tpl (toYaml .selectors) $root | nindent 8 }}
+      ports:
+        {{- if .ports }}
+        {{- toYaml .ports | nindent 8 }}
+        {{- else }}
+        - port: {{ $root.Values.service.targetPort }}
+          protocol: TCP
+        {{- end }}
+    {{- end }}
+  egress:
+    # DNS is always permitted so the pod can resolve backend service names.
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- range .Values.networkPolicy.egressRules }}
+    - to:
+        {{- tpl (toYaml .selectors) $root | nindent 8 }}
+      {{- with .ports }}
+      ports:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/lunasea-web/templates/secret-basic-auth.yaml
+++ b/charts/lunasea-web/templates/secret-basic-auth.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.basicAuth.enabled (not .Values.basicAuth.existingSecret) }}
+{{- if not .Values.basicAuth.htpasswd }}
+{{- fail "basicAuth.enabled is true but neither basicAuth.existingSecret nor basicAuth.htpasswd is set. Provide an htpasswd string (e.g. `htpasswd -nbB <user> <pass>`)." }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "lunasea-web.basicAuthSecretName" . }}
+  labels:
+    {{- include "lunasea-web.labels" . | nindent 4 }}
+# Opaque secret carrying the htpasswd payload under both conventional keys so a
+# single secret serves ingress-nginx (key "auth") and NGINX Gateway Fabric (key "htpasswd").
+type: Opaque
+stringData:
+  auth: |-
+    {{- .Values.basicAuth.htpasswd | nindent 4 }}
+  htpasswd: |-
+    {{- .Values.basicAuth.htpasswd | nindent 4 }}
+{{- end }}

--- a/charts/lunasea-web/templates/secret-basic-auth.yaml
+++ b/charts/lunasea-web/templates/secret-basic-auth.yaml
@@ -8,12 +8,12 @@ metadata:
   name: {{ include "lunasea-web.basicAuthSecretName" . }}
   labels:
     {{- include "lunasea-web.labels" . | nindent 4 }}
-# Opaque secret carrying the htpasswd payload under both conventional keys so a
-# single secret serves ingress-nginx (key "auth") and NGINX Gateway Fabric (key "htpasswd").
+# Opaque secret holding the htpasswd payload under key "auth". Both ingress-nginx
+# (auth-secret annotation) and NGINX Gateway Fabric's AuthenticationFilter read the
+# "auth" key. The deprecated nginx.org/htpasswd secret type also used key "auth";
+# only the type changed to Opaque, not the key.
 type: Opaque
 stringData:
   auth: |-
-    {{- .Values.basicAuth.htpasswd | nindent 4 }}
-  htpasswd: |-
     {{- .Values.basicAuth.htpasswd | nindent 4 }}
 {{- end }}

--- a/charts/lunasea-web/templates/service.yaml
+++ b/charts/lunasea-web/templates/service.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lunasea-web.fullname" . }}
+  labels:
+    {{- include "lunasea-web.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "lunasea-web.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lunasea-web.headlessServiceName" . }}
+  labels:
+    {{- include "lunasea-web.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "lunasea-web.selectorLabels" . | nindent 4 }}

--- a/charts/lunasea-web/templates/service.yaml
+++ b/charts/lunasea-web/templates/service.yaml
@@ -17,20 +17,3 @@ spec:
       name: http
   selector:
     {{- include "lunasea-web.selectorLabels" . | nindent 4 }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "lunasea-web.headlessServiceName" . }}
-  labels:
-    {{- include "lunasea-web.labels" . | nindent 4 }}
-spec:
-  type: ClusterIP
-  clusterIP: None
-  ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
-  selector:
-    {{- include "lunasea-web.selectorLabels" . | nindent 4 }}

--- a/charts/lunasea-web/templates/serviceaccount.yaml
+++ b/charts/lunasea-web/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lunasea-web.serviceAccountName" . }}
+  labels:
+    {{- include "lunasea-web.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/lunasea-web/templates/statefulset.yaml
+++ b/charts/lunasea-web/templates/statefulset.yaml
@@ -17,13 +17,16 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- $secretChecksum := and .Values.basicAuth.enabled (not .Values.basicAuth.existingSecret) }}
+      {{- if or $secretChecksum .Values.podAnnotations }}
       annotations:
-        {{- if and .Values.basicAuth.enabled (not .Values.basicAuth.existingSecret) }}
+        {{- if $secretChecksum }}
         checksum/secret: {{ include (print .Template.BasePath "/secret-basic-auth.yaml") . | sha256sum | trunc 63 }}
         {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/lunasea-web/templates/statefulset.yaml
+++ b/charts/lunasea-web/templates/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "lunasea-web.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  serviceName: {{ include "lunasea-web.headlessServiceName" . }}
+  serviceName: {{ include "lunasea-web.fullname" . }}
   selector:
     matchLabels:
       {{- include "lunasea-web.selectorLabels" . | nindent 6 }}

--- a/charts/lunasea-web/templates/statefulset.yaml
+++ b/charts/lunasea-web/templates/statefulset.yaml
@@ -1,0 +1,143 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "lunasea-web.fullname" . }}
+  labels:
+    {{- include "lunasea-web.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  serviceName: {{ include "lunasea-web.headlessServiceName" . }}
+  selector:
+    matchLabels:
+      {{- include "lunasea-web.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lunasea-web.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- if and .Values.basicAuth.enabled (not .Values.basicAuth.existingSecret) }}
+        checksum/secret: {{ include (print .Template.BasePath "/secret-basic-auth.yaml") . | sha256sum | trunc 63 }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "lunasea-web.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ coalesce .Values.image.tag .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: LUNASEA_ADDR
+              value: ":{{ .Values.service.targetPort }}"
+            - name: LUNASEA_DATA_DIR
+              value: {{ .Values.persistence.mountPath | quote }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+              {{- with .Values.persistence.subPath }}
+              subPath: {{ . }}
+              {{- end }}
+            - name: tmp
+              mountPath: /tmp
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- if not .Values.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- else if .Values.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        {{- with .Values.persistence.labels }}
+        labels:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          - {{ .Values.persistence.accessMode }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+        volumeMode: Filesystem
+        {{- if .Values.persistence.storageClass }}
+        {{- if (eq "-" .Values.persistence.storageClass) }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: {{ .Values.persistence.storageClass }}
+        {{- end }}
+        {{- end }}
+  {{- end }}

--- a/charts/lunasea-web/templates/tests/test-connection.yaml
+++ b/charts/lunasea-web/templates/tests/test-connection.yaml
@@ -9,10 +9,22 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: wget
       image: "{{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}"
       imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
       command: ["wget"]
       args:
         - "--spider"

--- a/charts/lunasea-web/templates/tests/test-connection.yaml
+++ b/charts/lunasea-web/templates/tests/test-connection.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "lunasea-web.fullname" . }}-test-connection"
+  labels:
+    {{- include "lunasea-web.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: wget
+      image: "{{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}"
+      imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
+      command: ["wget"]
+      args:
+        - "--spider"
+        - "-S"
+        - "http://{{ include "lunasea-web.fullname" . }}:{{ .Values.service.port }}/"

--- a/charts/lunasea-web/values.schema.json
+++ b/charts/lunasea-web/values.schema.json
@@ -134,7 +134,8 @@
         "hostnames": { "type": "array", "items": { "type": "string" } },
         "matches": { "type": "array" },
         "extraFilters": { "type": "array" },
-        "publicPathPrefixes": { "type": "array", "items": { "type": "string" } }
+        "publicPathPrefixes": { "type": "array", "items": { "type": "string" } },
+        "publicPaths": { "type": "array", "items": { "type": "string" } }
       }
     },
     "networkPolicy": {

--- a/charts/lunasea-web/values.schema.json
+++ b/charts/lunasea-web/values.schema.json
@@ -136,6 +136,37 @@
         "extraFilters": { "type": "array" }
       }
     },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "annotations": { "type": "object" },
+        "labels": { "type": "object" },
+        "ingressRules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["selectors"],
+            "properties": {
+              "selectors": { "type": "array", "items": { "type": "object" } },
+              "ports": { "type": "array", "items": { "type": "object" } }
+            }
+          }
+        },
+        "egressRules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["selectors"],
+            "properties": {
+              "selectors": { "type": "array", "items": { "type": "object" } },
+              "ports": { "type": "array", "items": { "type": "object" } }
+            }
+          }
+        }
+      }
+    },
     "tests": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/lunasea-web/values.schema.json
+++ b/charts/lunasea-web/values.schema.json
@@ -134,6 +134,7 @@
         "hostnames": { "type": "array", "items": { "type": "string" } },
         "matches": { "type": "array" },
         "extraFilters": { "type": "array" },
+        "bypassAuthForPWA": { "type": "boolean" },
         "publicPathPrefixes": { "type": "array", "items": { "type": "string" } },
         "publicPaths": { "type": "array", "items": { "type": "string" } }
       }

--- a/charts/lunasea-web/values.schema.json
+++ b/charts/lunasea-web/values.schema.json
@@ -133,7 +133,8 @@
         },
         "hostnames": { "type": "array", "items": { "type": "string" } },
         "matches": { "type": "array" },
-        "extraFilters": { "type": "array" }
+        "extraFilters": { "type": "array" },
+        "publicPathPrefixes": { "type": "array", "items": { "type": "string" } }
       }
     },
     "networkPolicy": {

--- a/charts/lunasea-web/values.schema.json
+++ b/charts/lunasea-web/values.schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "lunasea-web values",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "pullPolicy"],
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      }
+    },
+    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "annotations": { "type": "object" }
+      }
+    },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "port", "targetPort"],
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "targetPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "annotations": { "type": "object" }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "accessMode": { "type": "string", "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany", "ReadWriteOncePod"] },
+        "existingClaim": { "type": "string" },
+        "mountPath": { "type": "string", "minLength": 1 },
+        "subPath": { "type": "string" },
+        "storageClass": { "type": "string" },
+        "size": { "type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?(Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|k|m)?$" },
+        "labels": { "type": "object" },
+        "annotations": { "type": "object" }
+      }
+    },
+    "resources": { "type": "object" },
+    "startupProbe": { "type": ["object", "null"] },
+    "livenessProbe": { "type": ["object", "null"] },
+    "readinessProbe": { "type": ["object", "null"] },
+    "extraEnv": { "type": "array" },
+    "extraVolumes": { "type": "array" },
+    "extraVolumeMounts": { "type": "array" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array" },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array" },
+    "basicAuth": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "realm": { "type": "string" },
+        "existingSecret": { "type": "string" },
+        "htpasswd": { "type": "string" }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "annotations": { "type": "object" },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["host"],
+            "properties": {
+              "host": { "type": "string" },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["path"],
+                  "properties": {
+                    "path": { "type": "string" },
+                    "pathType": { "type": "string", "enum": ["Prefix", "Exact", "ImplementationSpecific"] }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": { "type": "array" }
+      }
+    },
+    "httpRoute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "parentRefs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": { "type": "string" },
+              "namespace": { "type": "string" },
+              "group": { "type": "string" },
+              "kind": { "type": "string" },
+              "sectionName": { "type": "string" }
+            }
+          }
+        },
+        "hostnames": { "type": "array", "items": { "type": "string" } },
+        "matches": { "type": "array" },
+        "extraFilters": { "type": "array" }
+      }
+    },
+    "tests": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["repository", "tag", "pullPolicy"],
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/lunasea-web/values.yaml
+++ b/charts/lunasea-web/values.yaml
@@ -142,8 +142,9 @@ basicAuth:
   enabled: false
   # -- Authentication realm
   realm: LunaSea
-  # -- Use an existing secret (must contain keys "auth" and/or "htpasswd").
-  # When set, the chart does not create a secret.
+  # -- Use an existing secret. It MUST contain an htpasswd payload under the key
+  # "auth" (read by both ingress-nginx and the NGINX Gateway Fabric
+  # AuthenticationFilter). When set, the chart does not create a secret.
   existingSecret: ""
   # -- htpasswd payload used to create the secret when existingSecret is empty.
   # Generate with: htpasswd -nbB <user> <pass>

--- a/charts/lunasea-web/values.yaml
+++ b/charts/lunasea-web/values.yaml
@@ -188,15 +188,17 @@ httpRoute:
   matches: []
   # -- Additional HTTPRoute filters appended after the auth filter
   extraFilters: []
-  # -- PathPrefix matches served WITHOUT the basic-auth AuthenticationFilter
-  # (only applies when basicAuth.enabled). PathPrefix matches per path segment,
-  # so use this for directories/exact paths like "/manifest.json" or "/assets".
+  # -- Serve the LunaSea PWA manifest + icons without the basic-auth
+  # AuthenticationFilter (only applies when basicAuth.enabled). The OS fetches
+  # these without credentials when adding the site to the home screen, so
+  # otherwise the home-screen icon is blank. The exact asset paths are built
+  # into the chart template — no need to enumerate them.
+  bypassAuthForPWA: true
+  # -- Extra PathPrefix matches served WITHOUT basic auth (in addition to the
+  # built-in PWA assets). PathPrefix matches per path segment.
   publicPathPrefixes: []
-  # -- Exact paths served WITHOUT the basic-auth AuthenticationFilter (only
-  # applies when basicAuth.enabled). Use for root-level PWA assets the OS
-  # fetches without credentials when adding to the home screen — otherwise the
-  # icon is blank. PathPrefix can't match these ("/apple-icon" != the file
-  # "/apple-icon-180x180.png"), so list the exact filenames here.
+  # -- Extra Exact paths served WITHOUT basic auth (in addition to the built-in
+  # PWA assets).
   publicPaths: []
 
 # NetworkPolicy — restrict pod traffic. Requires a CNI/controller that enforces

--- a/charts/lunasea-web/values.yaml
+++ b/charts/lunasea-web/values.yaml
@@ -189,6 +189,44 @@ httpRoute:
   # -- Additional HTTPRoute filters appended after the auth filter
   extraFilters: []
 
+# NetworkPolicy — restrict pod traffic. Requires a CNI/controller that enforces
+# NetworkPolicies (k3s bundled kube-router, Calico, Cilium, ...). When enabled,
+# DNS egress (port 53) is always permitted; everything else is denied unless
+# listed below. lunasea-web's gateway only ever talks to the backends you
+# configure (Radarr/Sonarr/SABnzbd/...) — it makes no direct internet requests —
+# so a backends-only egress allowlist is sufficient.
+networkPolicy:
+  # -- Create a NetworkPolicy for the pod
+  enabled: false
+  # -- Extra annotations for the NetworkPolicy
+  annotations: {}
+  # -- Extra labels for the NetworkPolicy
+  labels: {}
+  # -- Ingress allowlist. Each entry has `selectors` (a list of NetworkPolicy
+  # peers, templated) and optional `ports` (defaults to service.targetPort).
+  # Empty means no ingress is allowed.
+  ingressRules: []
+    # - selectors:
+    #     - namespaceSelector:
+    #         matchLabels:
+    #           kubernetes.io/metadata.name: nginx-gateway
+    #   ports:
+    #     - port: 8080
+    #       protocol: TCP
+  # -- Egress allowlist. Each entry has `selectors` and optional `ports`.
+  # DNS (port 53) is always permitted automatically.
+  egressRules: []
+    # - selectors:
+    #     - namespaceSelector:
+    #         matchLabels:
+    #           kubernetes.io/metadata.name: media
+    #       podSelector:
+    #         matchLabels:
+    #           app.kubernetes.io/name: radarr
+    #   ports:
+    #     - port: 7878
+    #       protocol: TCP
+
 tests:
   image:
     # -- Image used by the helm test connection pod

--- a/charts/lunasea-web/values.yaml
+++ b/charts/lunasea-web/values.yaml
@@ -188,11 +188,16 @@ httpRoute:
   matches: []
   # -- Additional HTTPRoute filters appended after the auth filter
   extraFilters: []
-  # -- Path prefixes served WITHOUT the basic-auth AuthenticationFilter (only
-  # applies when basicAuth.enabled). Use for PWA assets the OS fetches without
-  # credentials when adding to the home screen — otherwise the icon is blank.
-  # e.g. ["/manifest.json", "/apple-icon", "/android-icon", "/favicon"]
+  # -- PathPrefix matches served WITHOUT the basic-auth AuthenticationFilter
+  # (only applies when basicAuth.enabled). PathPrefix matches per path segment,
+  # so use this for directories/exact paths like "/manifest.json" or "/assets".
   publicPathPrefixes: []
+  # -- Exact paths served WITHOUT the basic-auth AuthenticationFilter (only
+  # applies when basicAuth.enabled). Use for root-level PWA assets the OS
+  # fetches without credentials when adding to the home screen — otherwise the
+  # icon is blank. PathPrefix can't match these ("/apple-icon" != the file
+  # "/apple-icon-180x180.png"), so list the exact filenames here.
+  publicPaths: []
 
 # NetworkPolicy — restrict pod traffic. Requires a CNI/controller that enforces
 # NetworkPolicies (k3s bundled kube-router, Calico, Cilium, ...). When enabled,

--- a/charts/lunasea-web/values.yaml
+++ b/charts/lunasea-web/values.yaml
@@ -188,6 +188,11 @@ httpRoute:
   matches: []
   # -- Additional HTTPRoute filters appended after the auth filter
   extraFilters: []
+  # -- Path prefixes served WITHOUT the basic-auth AuthenticationFilter (only
+  # applies when basicAuth.enabled). Use for PWA assets the OS fetches without
+  # credentials when adding to the home screen — otherwise the icon is blank.
+  # e.g. ["/manifest.json", "/apple-icon", "/android-icon", "/favicon"]
+  publicPathPrefixes: []
 
 # NetworkPolicy — restrict pod traffic. Requires a CNI/controller that enforces
 # NetworkPolicies (k3s bundled kube-router, Calico, Cilium, ...). When enabled,

--- a/charts/lunasea-web/values.yaml
+++ b/charts/lunasea-web/values.yaml
@@ -1,0 +1,198 @@
+# -- Number of replicas. LunaSea stores config in a single RWO SQLite volume, so
+# this should stay at 1 unless you provide ReadWriteMany storage.
+replicaCount: 1
+
+image:
+  # -- Image repository
+  repository: ghcr.io/alysson-souza/lunasea-web
+  # -- Image tag. Defaults to the chart appVersion when empty.
+  tag: ""
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+# -- Secrets for pulling the image from a private registry
+imagePullSecrets: []
+
+# -- Override the chart name
+nameOverride: ""
+# -- Override the fully qualified app name
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Create a dedicated ServiceAccount
+  create: true
+  # -- Name of the ServiceAccount to use (generated if empty and create is true)
+  name: ""
+  # -- Annotations for the ServiceAccount
+  annotations: {}
+
+# -- Extra labels for the pod
+podLabels: {}
+# -- Extra annotations for the pod
+podAnnotations: {}
+
+# -- Pod-level security context. Matches the image's non-root user (65532).
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Container-level security context. The image runs read-only by design; the
+# chart mounts writable /tmp and the persistent /data volume.
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Service port
+  port: 8080
+  # -- Container port the application listens on (sets LUNASEA_ADDR)
+  targetPort: 8080
+  # -- Additional annotations for the Service
+  annotations: {}
+
+persistence:
+  # -- Enable persistence for /data (SQLite database with all configuration).
+  # When disabled, an emptyDir is used and configuration is lost on pod restart.
+  enabled: true
+  # -- Access mode for the PVC
+  accessMode: ReadWriteOnce
+  # -- Use an existing PVC instead of provisioning one
+  existingClaim: ""
+  # -- Mount path for persistent data (sets LUNASEA_DATA_DIR)
+  mountPath: /data
+  # -- Subpath within the volume to mount
+  subPath: ""
+  ## Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default), no storageClassName is set, choosing the default provisioner.
+  # storageClass: "-"
+  # -- Size of the persistent volume
+  size: 1Gi
+  # -- Extra labels for the PVC
+  labels: {}
+  # -- Extra annotations for the PVC
+  annotations: {}
+
+resources: {}
+  # We usually recommend not specifying default resources and leaving this as a
+  # conscious choice for the user. Uncomment and tune for your environment:
+  # limits:
+  #   cpu: 500m
+  #   memory: 256Mi
+  # requests:
+  #   cpu: 50m
+  #   memory: 64Mi
+
+# -- Startup probe. The app serves index.html on / with a 200.
+startupProbe:
+  httpGet:
+    path: /
+    port: http
+  failureThreshold: 30
+  periodSeconds: 5
+# -- Liveness probe
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 15
+# -- Readiness probe
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 3
+  periodSeconds: 10
+
+# -- Extra environment variables for the container
+extraEnv: []
+  # - name: LUNASEA_STATIC_DIR
+  #   value: /usr/share/lunasea/web
+
+# -- Additional volumes for the pod
+extraVolumes: []
+# -- Additional volume mounts for the container
+extraVolumeMounts: []
+
+# -- Node selector for pod scheduling
+nodeSelector: {}
+# -- Tolerations for pod scheduling
+tolerations: []
+# -- Affinity rules for pod scheduling
+affinity: {}
+# -- Topology spread constraints
+topologySpreadConstraints: []
+
+# Basic Auth — shared by both Ingress and the HTTPRoute AuthenticationFilter.
+# LunaSea has no built-in auth, so enabling this is strongly recommended for any
+# externally reachable deployment.
+basicAuth:
+  # -- Enable HTTP Basic Auth
+  enabled: false
+  # -- Authentication realm
+  realm: LunaSea
+  # -- Use an existing secret (must contain keys "auth" and/or "htpasswd").
+  # When set, the chart does not create a secret.
+  existingSecret: ""
+  # -- htpasswd payload used to create the secret when existingSecret is empty.
+  # Generate with: htpasswd -nbB <user> <pass>
+  htpasswd: ""
+
+ingress:
+  # -- Enable Ingress record generation
+  enabled: false
+  # -- IngressClass that will be used
+  className: ""
+  # -- Additional annotations for the Ingress (auth-* annotations are added
+  # automatically when basicAuth.enabled is true)
+  annotations: {}
+  # -- Ingress hosts
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- Ingress TLS configuration
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# Gateway API HTTPRoute — alternative to Ingress for clusters running
+# NGINX Gateway Fabric (or another Gateway API implementation). When
+# basicAuth.enabled is true, an AuthenticationFilter is attached as an
+# ExtensionRef filter (NGINX Gateway Fabric specific).
+httpRoute:
+  # -- Enable HTTPRoute generation
+  enabled: false
+  # -- Gateways this route attaches to
+  parentRefs: []
+  #  - name: nginx-gateway
+  #    namespace: nginx-gateway
+  # -- Hostnames for the route
+  hostnames: []
+  #  - lunasea.example.com
+  # -- Path matches (defaults to PathPrefix "/" when empty)
+  matches: []
+  # -- Additional HTTPRoute filters appended after the auth filter
+  extraFilters: []
+
+tests:
+  image:
+    # -- Image used by the helm test connection pod
+    repository: busybox
+    # -- Image tag for the test pod
+    tag: "1.37"
+    # -- Pull policy for the test pod image
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

New Helm chart `charts/lunasea-web` packaging [alysson-souza/lunasea-web](https://github.com/alysson-souza/lunasea-web) — the self-hosted web build of LunaSea (controller dashboard for Radarr/Sonarr/Lidarr/SABnzbd/NZBGet/Tautulli/...).

Follows existing repo conventions (`charts/mosquitto`, `charts/doh-server`) plus modern best-practice extras: `values.schema.json` and a `helm test`.

### Highlights
- **StatefulSet** with `volumeClaimTemplates` for the SQLite `/data` volume (emptyDir fallback when `persistence.enabled=false`).
- **Secure defaults** matching the distroless image: non-root `65532`, `readOnlyRootFilesystem`, dropped capabilities, `RuntimeDefault` seccomp; writable `/tmp` + `/data`.
- Env wired from values: `LUNASEA_ADDR=:8080`, `LUNASEA_DATA_DIR=/data`.
- **Basic Auth pre-wired for both routers** (LunaSea has no built-in auth — must never be public), sharing one Opaque secret carrying both conventional keys:
  - **Ingress** → `nginx.ingress.kubernetes.io/auth-*` annotations (key `auth`)
  - **HTTPRoute** → `AuthenticationFilter` (`gateway.nginx.org/v1alpha1`) ExtensionRef filter (key `htpasswd`) — matches the cluster's NGINX Gateway Fabric pattern.
- `values.schema.json` validation + `helm test` connection pod + NOTES.txt.
- `ci/{default,full}-values.yaml` for chart-testing.

## Test plan
- [x] `helm lint` (default + full-values) — clean
- [x] `kubeconform -strict -ignore-missing-schemas` — full-values 7/7 valid; httpRoute+auth path 6 valid + 2 CRD-skipped (expected)
- [x] `helm install` on KinD v1.33.1 — pod 1/1 Running, PVC bound, image pulled
- [x] `helm test` — Succeeded
- [x] schema rejects invalid input (`service.type=Bogus`); basicAuth fail-guard without htpasswd
- [ ] CI `ct lint` / `ct install`