### PR TITLE
add mautrix-telegram chart

### DIFF
--- a/charts/mautrix-telegram/.helmignore
+++ b/charts/mautrix-telegram/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/mautrix-telegram/Chart.yaml
+++ b/charts/mautrix-telegram/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: mautrix-telegram
+description: A Matrix-Telegram puppeting bridge
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+# renovate: datasource=github-releases depName=mautrix/telegram
+appVersion: "v0.2606.0"

--- a/charts/mautrix-telegram/ci/bridge-values.yaml
+++ b/charts/mautrix-telegram/ci/bridge-values.yaml
@@ -1,0 +1,5 @@
+livenessProbe: null
+readinessProbe: null
+
+command: ["/bin/sh", "-c"]
+args: ["sleep 3600"]

--- a/charts/mautrix-telegram/templates/_helpers.tpl
+++ b/charts/mautrix-telegram/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mautrix-telegram.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mautrix-telegram.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mautrix-telegram.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mautrix-telegram.labels" -}}
+helm.sh/chart: {{ include "mautrix-telegram.chart" . }}
+{{ include "mautrix-telegram.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mautrix-telegram.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mautrix-telegram.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mautrix-telegram.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mautrix-telegram.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/mautrix-telegram/templates/configmap.yaml
+++ b/charts/mautrix-telegram/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mautrix-telegram.fullname" . }}
+  labels:
+{{ include "mautrix-telegram.labels" . | indent 4 }}
+data:
+  config.yaml: {{ .Values.config | toYaml | quote }}

--- a/charts/mautrix-telegram/templates/deployment.yaml
+++ b/charts/mautrix-telegram/templates/deployment.yaml
@@ -1,0 +1,134 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mautrix-telegram.fullname" . }}
+  labels:
+    {{- include "mautrix-telegram.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "mautrix-telegram.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "mautrix-telegram.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "mautrix-telegram.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: {{ default "Always" .Values.restartPolicy }}
+      initContainers:
+      {{- if .Values.initContainers }}
+        {{- if eq (typeOf .Values.initContainers) "string" }}
+        {{- tpl .Values.initContainers . | nindent 8 }}
+        {{- else }}
+        {{- toYaml .Values.initContainers | nindent 8 }}
+        {{- end }}
+      {{- end }}
+        - name: config
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [ "/bin/bash" ]
+          args:
+            - -xc
+            - |
+              cp -v /config/config.yaml /data
+              cp -v /registration/registration.yaml /data
+              chown -v $UID:$GUID /data/*.yaml
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /config
+            - name: registration
+              mountPath: /registration
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ ((.Values.config).appservice).port | default "29318" }}
+              protocol: TCP
+            {{- if ((.Values.config).metrics).enabled }}
+            - name: metrics
+              containerPort: {{ .Values.config.metrics.listen_port }}
+              protocol: TCP
+            {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+        {{- with .Values.extraContainers }}
+        {{- if eq (typeOf .) "string" }}
+        {{- tpl . $ | nindent 8 }}
+        {{- else }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
+      volumes:
+        - name: registration
+          secret:
+            secretName: {{ include "mautrix-telegram.fullname" . }}
+        - name: config
+          configMap:
+            name: {{ include "mautrix-telegram.fullname" . }}
+        - name: data
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/mautrix-telegram/templates/ingress.yaml
+++ b/charts/mautrix-telegram/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "mautrix-telegram.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "mautrix-telegram.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/mautrix-telegram/templates/prometheusrule.yaml
+++ b/charts/mautrix-telegram/templates/prometheusrule.yaml
@@ -1,0 +1,14 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "mautrix-telegram.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mautrix-telegram.labels" . | nindent 4 }}
+spec:
+  groups:
+  - name: {{ template "mautrix-telegram.name" . }}
+    rules:
+{{- toYaml .Values.prometheusRule.spec | nindent 4 }}
+{{- end }}

--- a/charts/mautrix-telegram/templates/secret.yaml
+++ b/charts/mautrix-telegram/templates/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mautrix-telegram.fullname" . }}
+  labels:
+{{ include "mautrix-telegram.labels" . | indent 4 }}
+type: Opaque
+data:
+  registration.yaml: {{ .Values.registration | toYaml | b64enc | quote }}

--- a/charts/mautrix-telegram/templates/service.yaml
+++ b/charts/mautrix-telegram/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mautrix-telegram.fullname" . }}
+  labels:
+    {{- include "mautrix-telegram.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  publishNotReadyAddresses: true
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    {{- if ((.Values.config).metrics).enabled }}
+    - port: {{ .Values.config.metrics.listen_port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- end }}
+  selector:
+    {{- include "mautrix-telegram.selectorLabels" . | nindent 4 }}

--- a/charts/mautrix-telegram/templates/serviceaccount.yaml
+++ b/charts/mautrix-telegram/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mautrix-telegram.serviceAccountName" . }}
+  labels:
+    {{- include "mautrix-telegram.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/mautrix-telegram/templates/servicemonitor.yaml
+++ b/charts/mautrix-telegram/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "mautrix-telegram.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "mautrix-telegram.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - interval: {{ .Values.serviceMonitor.interval }}
+      {{- if .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      honorLabels: true
+      port: metrics
+      path: /metrics
+      scheme: http
+  selector:
+    matchLabels:
+      {{- include "mautrix-telegram.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/mautrix-telegram/values.yaml
+++ b/charts/mautrix-telegram/values.yaml
@@ -1,0 +1,127 @@
+image:
+  repository: dock.mau.dev/mautrix/telegram
+  pullPolicy: IfNotPresent
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  # runAsUser: 1000
+  # fsGroup: 1337
+
+initContainers: []
+
+extraContainers: []
+
+restartPolicy: Always
+
+service:
+  type: ClusterIP
+  port: 80
+
+serviceMonitor:
+  enabled: false
+  namespace: ""
+  labels: {}
+  interval: 10s
+  scrapeTimeout: 10s
+
+prometheusRule:
+  enabled: false
+  spec: []
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+hostAliases: []
+# - ip: 10.20.30.40
+#   hostnames:
+#   - git.myhostname
+
+livenessProbe:
+  httpGet:
+    path: /_matrix/mau/live
+    port: http
+
+readinessProbe:
+  httpGet:
+    path: /_matrix/mau/live
+    port: http
+
+config: {}
+
+registration: {}
+  # # Same as .config.appservice.id
+  # id: telegram
+  # # Same as .config.appservice.as_token
+  # as_token: ""
+  # # Same as .config.appservice.hs_token
+  # hs_token: ""
+  # # should match .config.homeserver.domain
+  # namespaces:
+  #     users:
+  #     - exclusive: true
+  #       regex: '@telegram_.*:example\.com'
+  #     - exclusive: true
+  #       regex: '@telegrambot:example\.com'
+  #     aliases: []
+  # # Either ingress.hosts.[].host
+  # # Or http://
+  # url: http://mautrix-telegram:29317
+  # # localpart (everything precedding @) in the bots matrix username
+  # # can be any random string
+  # sender_localpart: ""
+  # rate_limited: false


### PR DESCRIPTION
## Summary
Adds a Helm chart for [mautrix-telegram](https://github.com/mautrix/telegram), the Matrix↔Telegram puppeting bridge — mirroring the existing `mautrix-whatsapp` chart (both are the Go "megabridge", so templates and config schema match).

- Image: `dock.mau.dev/mautrix/telegram`
- `appVersion: v0.2606.0` (latest upstream), Renovate-tracked via `depName=mautrix/telegram`
- Renders the bridge config from `.Values.config` and the appservice registration from `.Values.registration` (ConfigMap + Secret), Deployment/Service/ServiceAccount, optional Ingress/ServiceMonitor/PrometheusRule.

## Test plan
- [x] `helm lint charts/mautrix-telegram` passes
- [x] `helm template` renders Deployment/Service/ConfigMap/Secret/ServiceAccount with image `dock.mau.dev/mautrix/telegram:v0.2606.0`
- [x] `pre-commit` passes
- [ ] CI: `ct lint` + KinD install